### PR TITLE
Added functionality for default, admins, and service acct group enforcement

### DIFF
--- a/PhylaxSettings.h
+++ b/PhylaxSettings.h
@@ -17,11 +17,15 @@ enum LogLevel {
 class PhylaxSettings {
 public:
     std::vector<std::wstring> enforcedGroups;
+    std::vector<std::wstring> adminGroups;
+    std::vector<std::wstring> serviceGroups;
     std::wstring logPath;
     std::wstring logName;
     DWORD logSize;
     DWORD logRetention;
     DWORD minimumLength;
+    DWORD adminMinLength;
+    DWORD serviceMinLength;
     DWORD complexity;
     bool rejectSequences;
     DWORD rejectSequencesLength;


### PR DESCRIPTION
Initial push only included enforcement based on a single password length requirement. Since users are forced to change their passwords at a set interval, admins have a higher level of access privileges, and service accounts often have non-expiring passwords, I have allowed three different sets of length enforcement. 